### PR TITLE
Change to sacred mound

### DIFF
--- a/jsons/Buildings.json
+++ b/jsons/Buildings.json
@@ -29,11 +29,10 @@
         "uniqueTo": "Wakanda",
         "isWonder": "true",
         "requiredTech": "Agriculture",
-        "cost": 1,
+        "cost": 600,
         "science": 1,
         "uniques": ["Provides [1] [Vibranium]",
-            "[+1 Culture, +1 Science, +1 Happiness, +1 Faith, +1 Gold, +1 Food, +1 Production] [in all cities]",
-            "Free [Black Panther] appears",
+            "[+2 Culture, +2 Science, +2 Happiness, +2 Faith, +2 Gold, +2 Food, +2 Production] [in all cities]",
             "Gain a free [Monument] [in this city]",
             "Will not be displayed in Civilopedia"],
         "quote": "'I have seen gods fly. I have seen men build weapons that I couldn't even imagine. I have seen aliens drop from the sky. But I have never seen anything like this.' - Everett K. Ross"


### PR DESCRIPTION
me again 
Mound no longer gives free black panther, thought that was a little redundant. Also has more production required.
Doubled the bonuses to stats.
I reccomend perhaps making it increase production when making black panther, around 15%? (don't know how me dumb stupid) Maybe could bring down production for black panther so that an increase would be more appropriate, I think this should be maybe around twice as much production to make. 